### PR TITLE
declare 'tree' executable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "tree.swift",
+    products: [
+        .executable(name: "tree", targets: ["tree-swift"])
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),


### PR DESCRIPTION
This change allows to install package executable via `mise` and `mint` tools

Original error
> mise ERROR No executables found in the package


`products` property description
> - products: The list of products that this package makes available for clients to use.